### PR TITLE
Auto-filter confessions made by fingerprints with a lot of net rejected confessions.

### DIFF
--- a/app/Http/Controllers/Admin/SettingsAdminController.php
+++ b/app/Http/Controllers/Admin/SettingsAdminController.php
@@ -2,9 +2,9 @@
 
 namespace NUSWhispers\Http\Controllers\Admin;
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Redirect;
 use anlutro\LaravelSettings\Facade as Settings;
+use Illuminate\Support\Facades\Redirect;
+use NUSWhispers\Http\Requests\AdminSettingsRequest;
 
 class SettingsAdminController extends AdminController
 {
@@ -23,9 +23,13 @@ class SettingsAdminController extends AdminController
         ]);
     }
 
-    public function postIndex(Request $request)
+    public function postIndex(AdminSettingsRequest $request)
     {
-        Settings::set('word_blacklist', $request->input('word_blacklist', ''));
+        Settings::set($request->only([
+            'word_blacklist',
+            'rejection_net_score',
+            'rejection_decay',
+        ]));
         Settings::save();
 
         return Redirect::back()->withMessage('Settings successfully saved.')

--- a/app/Http/Requests/AdminSettingsRequest.php
+++ b/app/Http/Requests/AdminSettingsRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace NUSWhispers\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AdminSettingsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'word_blacklist' => 'string',
+            'rejection_net_score' => 'numeric|min:0',
+            'rejection_decay' => 'numeric|min:0',
+        ];
+    }
+}

--- a/app/Listeners/FilterConfessionViaFingerprint.php
+++ b/app/Listeners/FilterConfessionViaFingerprint.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace NUSWhispers\Listeners;
+
+use Carbon\Carbon;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use NUSWhispers\Events\ConfessionWasCreated;
+use anlutro\LaravelSettings\Facade as Settings;
+use NUSWhispers\Models\Confession;
+
+class FilterConfessionViaFingerprint implements ShouldQueue
+{
+    /**
+     * Handle the event.
+     *
+     * @param  ConfessionWasCreated  $event
+     * @return mixed
+     */
+    public function handle(ConfessionWasCreated $event)
+    {
+        $threshold = (int) Settings::get('rejection_net_score', 5);
+        $decay = (int) Settings::get('rejection_decay', 30);
+
+        if (! $threshold || ! $decay) {
+            return true;
+        }
+
+        $confession = $event->confession;
+        $score = $this->getNetScore($confession->fingerprint, $decay);
+
+        if ($score > $threshold) {
+            $confession->update(['status' => 'Rejected']);
+        }
+    }
+
+    /**
+     * Get net score based on fingerprint.
+     *
+     * @param string $fingerprint
+     * @param int $decay
+     *
+     * @return int
+     */
+    protected function getNetScore($fingerprint, $decay)
+    {
+        $rejectedCount = Confession::rejected()
+            ->where('fingerprint', $fingerprint)
+            ->where('created_at', '>', Carbon::now()->subDays($decay))
+            ->count();
+
+        $approvedCount = Confession::approved()
+            ->where('fingerprint', $fingerprint)
+            ->where('created_at', '>', Carbon::now()->subDays($decay))
+            ->count();
+
+        return max(0, $rejectedCount - $approvedCount);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -15,6 +15,7 @@ class EventServiceProvider extends ServiceProvider
         'NUSWhispers\Events\ConfessionWasCreated' => [
             'NUSWhispers\Listeners\SyncConfessionTags',
             'NUSWhispers\Listeners\FilterConfessionViaWordBlacklist',
+            'NUSWhispers\Listeners\FilterConfessionViaFingerprint',
         ],
         'NUSWhispers\Events\ConfessionWasUpdated' => [
             'NUSWhispers\Listeners\SyncConfessionTags',
@@ -36,14 +37,4 @@ class EventServiceProvider extends ServiceProvider
             'NUSWhispers\Listeners\DeleteConfessionFromFacebook',
         ],
     ];
-
-    /**
-     * Register any events for your application.
-     *
-     * @return void
-     */
-    public function boot()
-    {
-        parent::boot();
-    }
 }

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -15,6 +15,19 @@
         <textarea class="form-control" name="word_blacklist" placeholder="List of words separated by commas" rows="5">{{ array_get($settings, 'word_blacklist', '') }}</textarea>
         <p class="help-block">Confessions with content within the word blacklist will be automatically rejected upon submission.</p>
       </div>
+      <hr />
+      <div class="form-group">
+        <label>Filter Errant Fingerprints</label>
+        <p class="form-inline">
+          Auto-reject confessors with a net number of
+            <input name="rejection_net_score" class="form-control" type="number" style="width: 5em; margin: 0 1em;" value="{{ array_get($settings, 'rejection_net_score', 5) }}" />
+          rejected confessions for the past
+            <input name="rejection_decay" class="form-control" type="number" style="width: 5em; margin: 0 1em;" value="{{ array_get($settings, 'rejection_decay', 30) }}" />
+          days.
+        </p>
+        <p class="help-block">Set 0 to any of the fields above to disable the filter.</p>
+      </div>
+      <hr />
       <p class="form-actions">
         <button class="btn btn-primary" type="submit">Submit</button>
       </p>

--- a/resources/views/message.blade.php
+++ b/resources/views/message.blade.php
@@ -5,3 +5,14 @@
 @if(\Session::has('message'))
 <p class="alert {{ Session::get('alert-class', 'alert-info') }}">{{ Session::get('message') }}</p>
 @endif
+
+@if($errors->any())
+  <div class="alert alert-danger">
+    Please fix the following validation errors:
+    <ul>
+      @foreach($errors->all() as $error)
+        <li>{{ $error }}</li>
+      @endforeach
+    </ul>
+  </div>
+@endif

--- a/tests/Listeners/FilterConfessionViaFingerprintTest.php
+++ b/tests/Listeners/FilterConfessionViaFingerprintTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace NUSWhispers\Tests\Listeners;
+
+use anlutro\LaravelSettings\Facade as Settings;
+use Carbon\Carbon;
+use Mockery;
+use NUSWhispers\Events\ConfessionWasCreated;
+use NUSWhispers\Listeners\FilterConfessionViaFingerprint;
+use NUSWhispers\Tests\TestCase;
+
+class FilterConfessionViaFingerprintTest extends TestCase
+{
+    protected $listener;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->listener = new FilterConfessionViaFingerprint();
+
+        Settings::shouldReceive('get')
+            ->with('rejection_net_score', Mockery::any())
+            ->andReturn(5);
+
+        Settings::shouldReceive('get')
+            ->with('rejection_decay', Mockery::any())
+            ->andReturn(30);
+    }
+
+    public function testHandle()
+    {
+        factory(\NUSWhispers\Models\Confession::class, 10)->create([
+            'status' => 'Rejected',
+            'fingerprint' => 'foo',
+        ]);
+
+        $confession = factory(\NUSWhispers\Models\Confession::class)->create([
+            'status' => 'Pending',
+            'fingerprint' => 'foo',
+        ]);
+
+        $this->listener->handle(new ConfessionWasCreated($confession));
+
+        $this->assertDatabaseHas('confessions', [
+            'confession_id' => $confession->getKey(),
+            'status' => 'Rejected',
+        ]);
+    }
+
+    public function testHandleDisabled()
+    {
+        // Calling the same expectation should override the previous one.
+        Settings::shouldReceive('get')
+            ->with('rejection_net_score', Mockery::any())
+            ->andReturn(0);
+
+        Settings::shouldReceive('get')
+            ->with('rejection_decay', Mockery::any())
+            ->andReturn(null);
+
+        factory(\NUSWhispers\Models\Confession::class, 10)->create([
+            'status' => 'Rejected',
+            'fingerprint' => 'foo',
+        ]);
+
+        $confession = factory(\NUSWhispers\Models\Confession::class)->create([
+            'status' => 'Pending',
+            'fingerprint' => 'foo',
+        ]);
+
+        $this->listener->handle(new ConfessionWasCreated($confession));
+
+        $this->assertDatabaseHas('confessions', [
+            'confession_id' => $confession->getKey(),
+            'status' => 'Rejected',
+        ]);
+    }
+
+    public function testHandleNewFingerprint()
+    {
+        $confession = factory(\NUSWhispers\Models\Confession::class)->create([
+            'status' => 'Pending',
+            'fingerprint' => 'foo',
+        ]);
+
+        $this->listener->handle(new ConfessionWasCreated($confession));
+
+        $this->assertDatabaseHas('confessions', [
+            'confession_id' => $confession->getKey(),
+            'status' => 'Pending',
+        ]);
+    }
+
+    public function testHandleNetScore()
+    {
+        factory(\NUSWhispers\Models\Confession::class, 10)->create([
+            'status' => 'Rejected',
+            'fingerprint' => 'foo',
+        ]);
+
+        factory(\NUSWhispers\Models\Confession::class, 10)->create([
+            'status' => 'Approved',
+            'fingerprint' => 'foo',
+        ]);
+
+        $confession = factory(\NUSWhispers\Models\Confession::class)->create([
+            'status' => 'Pending',
+            'fingerprint' => 'foo',
+        ]);
+
+        $this->listener->handle(new ConfessionWasCreated($confession));
+
+        $this->assertDatabaseHas('confessions', [
+            'confession_id' => $confession->getKey(),
+            'status' => 'Pending',
+        ]);
+    }
+
+    public function testHandleExpired()
+    {
+        factory(\NUSWhispers\Models\Confession::class, 10)->create([
+            'status' => 'Rejected',
+            'fingerprint' => 'foo',
+            'created_at' => Carbon::now()->subDays(30)->toDateTimeString(),
+        ]);
+
+        $confession = factory(\NUSWhispers\Models\Confession::class)->create([
+            'status' => 'Pending',
+            'fingerprint' => 'foo',
+        ]);
+
+        $this->listener->handle(new ConfessionWasCreated($confession));
+
+        $this->assertDatabaseHas('confessions', [
+            'confession_id' => $confession->getKey(),
+            'status' => 'Pending',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR will allow the system to auto-filter confessions made by the same fingerprint with multiple rejected confessions. Threshold and decay can be adjusted in the admin panel.

Formula: `(rejected from past n days - approved from past n days) > threshold`.